### PR TITLE
Fix: parodus crash with rdk_dbg_MsgRaw call stack

### DIFF
--- a/src/conn_interface.c
+++ b/src/conn_interface.c
@@ -231,8 +231,10 @@ void createSocketConnection(void (* initKeypress)())
     nopoll_cleanup_library();
     curl_global_cleanup();
     clear_metadata();
-    //disabling it due to local pc build failure
-    //rdk_logger_deinit();
+    //enabled for yocto buid, disabling for local pc due to build failure
+if (BUILD_YOCTO)	
+    rdk_logger_deinit();
+endif (BUILD_YOCTO)	
     free_server_list(&server_list);
 }
 


### PR DESCRIPTION
SHARMAN-2314: Observing Parodus crash in function _fini rdk_dbg_MsgRaw during multiple reboot execution, 
Adding rdk_logger_deinit() while parodus shutdown.